### PR TITLE
remove unexpected close bracket from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jsmediatags.read("./music-file.mp3", {
     console.log(tag);
   },
   onError: function(error) {
-    console.log(':(', error.type, error.info]);
+    console.log(':(', error.type, error.info);
   }
 });
 ```


### PR DESCRIPTION
Pasting the simple code example will not work due to an extra `]` character