### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ jsmediatags.read("filename.mp3", {
     var tags = tag.tags;
     alert(tags.artist + " - " + tags.title + ", " + tags.album);
   }
-);
+});
 ```
 
 ### Specific tags


### PR DESCRIPTION
An ending } was missing in one of the examples for migrating from JavaScript-ID3-Reader.