### PR TITLE
Add workaround for M4A cover recognized as 'uint8'

### DIFF
--- a/src/MP4TagReader.js
+++ b/src/MP4TagReader.js
@@ -208,6 +208,11 @@ class MP4TagReader extends MediaTagReader {
       var dataLength = atomSize - atomHeader;
       var atomData;
 
+      // Workaround for covers being parsed as 'uint8' type despite being an 'covr' atom
+      if (atomName === 'covr' && type === 'uint8') {
+        type = 'jpeg'
+      }
+
       switch (type) {
         case "text":
         atomData = data.getStringWithCharsetAt(dataStart, dataLength, "utf-8").toString();

--- a/src/__tests__/MP4TagReader-test.js
+++ b/src/__tests__/MP4TagReader-test.js
@@ -165,5 +165,27 @@ describe("MP4TagReader", function() {
     }).then(function(tag) {
       expect(Object.keys(tag.tags)).toContain("title");
     });
+
+    pit("reads jpeg tag despite uint8 type", function() {
+      var mp4FileContents = createMP4FileContents([
+        MP4TagContents.createMetadataAtom("covr", "uint8", [0x01, 0x02, 0x03])
+      ]);
+      var mediaFileReader = new ArrayFileReader(mp4FileContents.toArray());
+      var tagReader = new MP4TagReader(mediaFileReader);
+
+      return new Promise(function(resolve, reject) {
+        tagReader.read({
+          onSuccess: resolve,
+          onFailure: reject
+        });
+        jest.runAllTimers();
+      }).then(function(tag) {
+        var tags = tag.tags;
+        expect("covr" in tags).toBeTruthy();
+        expect(tags.covr.data.format).toBe("image/jpeg");
+        expect(tags.covr.data.data).toEqual([0x01, 0x02, 0x03]);
+      });
+    });
   });
 });
+


### PR DESCRIPTION
Cf Issue https://github.com/aadsm/jsmediatags/issues/26.