### PR TITLE
Support the atID, cnID, plID, geID, xid, and flvr iTunes/Quicktime tags

### DIFF
--- a/src/MP4TagReader.js
+++ b/src/MP4TagReader.js
@@ -221,6 +221,27 @@ class MP4TagReader extends MediaTagReader {
         case "uint8":
         atomData = data.getShortAt(dataStart, false);
         break;
+        
+        case "int":
+        case "uint":
+        // Though the QuickTime spec doesn't state it, there are 64-bit values
+        // such as plID (Playlist/Collection ID). With its single 64-bit floating
+        // point number type, these are hard to parse and pass in JavaScript.
+        // The high word of plID seems to always be zero, so, as this is the
+        // only current 64-bit atom handled, it is parsed from its 32-bit
+        // low word as an unsigned long.
+        //
+        var intReader = type == 'int'
+                          ? ( dataLength == 1 ? data.getSByteAt :
+                              dataLength == 2 ? data.getSShortAt :
+                              dataLength == 4 ? data.getSLongAt :
+                                                data.getLongAt)
+                          : ( dataLength == 1 ? data.getByteAt :
+                              dataLength == 2 ? data.getShortAt :
+                                                data.getLongAt);
+        
+        atomData = intReader.call(data, dataStart + (dataLength == 8 ? 4 : 0), true);
+        break;
 
         case "jpeg":
         case "png":
@@ -245,12 +266,16 @@ class MP4TagReader extends MediaTagReader {
   }
 }
 
+/*
+ * https://developer.apple.com/library/content/documentation/QuickTime/QTFF/Metadata/Metadata.html#//apple_ref/doc/uid/TP40000939-CH1-SW35
+*/
 const TYPES = {
   "0": "uint8",
   "1": "text",
   "13": "jpeg",
   "14": "png",
-  "21": "uint8"
+  "21": "int",
+  "22": "uint"
 };
 
 const ATOM_DESCRIPTIONS = {
@@ -296,6 +321,12 @@ const ATOM_DESCRIPTIONS = {
   "pgap": "Gapless Playback",
   "apID": "Purchase Account",
   "sfID": "Country Code",
+  "atID": "Artist ID",
+  "cnID": "Catalog ID",
+  "plID": "Collection ID",
+  "geID": "Genre ID",
+  "xid ": "Vendor Information",
+  "flvr": "Codec Flavor"
 };
 
 const UNSUPPORTED_ATOMS = {


### PR DESCRIPTION
1. Adds descriptions for the previously-unknown atoms in an iTunes m4a file — except for cmID, because I'm not sure how the Quicktime "Camera ID" description applies to audio files.

2. I described "xid" as "Vendor Information". From the looks of it, a more precise description may be "Vendor Catalog ID", but I'm not sure this is universally true, so my description is more vague.

3. Allows the integer atID, cnID, plID, and geID fields to be correctly parsed. The PlaylistID, plID, is actually a 64-bit value, but to save a lot of 64-bit effort for possibly nothing because the high-long seems to be always zero, all 64-bit values are parsed from their low 32 bits.



