### PR TITLE
Workaround for 3-character tags padded by NUL-byte

### DIFF
--- a/src/ID3v2FrameReader.js
+++ b/src/ID3v2FrameReader.js
@@ -313,6 +313,11 @@ class ID3v2FrameReader {
       frameId = "";
     }
 
+    // Some 3-character tags are padded by a NUL-byte.
+    if (frameId.charAt(3) == String.fromCharCode(0)) {
+      frameId = frameId.substring(0, 3)
+    }
+
     // if frameId is empty then it's the last frame
     if (frameId) {
       // read frame message and format flags

--- a/src/__tests__/ID3v2TagReader-test.js
+++ b/src/__tests__/ID3v2TagReader-test.js
@@ -238,6 +238,35 @@ describe("ID3v2TagReader", function() {
         expect(tags.tags.picture.data).toEqual([0x01, 0x02, 0xff, 0x03, 0x04, 0x05]);
       });
     });
+
+    pit("reads content with 3-character tag padded by NUL byte", function() {
+      var id3FileContents =
+        new ID3v2TagContents(4, 3)
+          .addFrame("PIC\u0000", [].concat(
+            [0x00], // text encoding
+            bin("image/jpeg"), [0x00],
+            [0x03], // picture type - cover front
+            bin("front cover image"), [0x00],
+            [0x01, 0x02, 0xff, 0x00, 0x03, 0x04, 0x05] // image data
+          ), {
+            format: {
+              unsynchronisation: true,
+              data_length_indicator: true,
+            },
+          }, 37);
+      mediaFileReader = new ArrayFileReader(id3FileContents.toArray());
+      tagReader = new ID3v2TagReader(mediaFileReader);
+
+      return new Promise(function(resolve, reject) {
+        tagReader.read({
+          onSuccess: resolve,
+          onFailure: reject
+        });
+        jest.runAllTimers();
+      }).then(function(tags) {
+        expect(tags.tags.picture.data).toEqual([0x01, 0x02, 0xff, 0x03, 0x04, 0x05]);
+      });
+    });
   });
 
   pit("should process frames with no content", function() {


### PR DESCRIPTION
Hello,

Thanks for providing a great library. I noticed an issue trying to load the attached picture for files that happen to use a `NUL` byte (`\u0000`) to pad 3-character tags.

The file for which I encountered the issue can be found here: [download link](http://audio.isosine.com/Isosine%20-%20Nonstop%20Pop%202016.mp3)

It uses the `PIC` tag to attach its album art, but when I use `jsmediatags` to parse all tags, I get:
```
  'PIC\u0000':
   { id: 'PIC\u0000',
     size: 504551,
     description: 'Unknown',
     data: null },
```

Clearly, the `PIC` frame reader isn't running since the tag doesn't match when the `NUL` byte is included. Hopefully this PR resolves the issue by just trimming off the padding byte if it is encountered.

I noticed the contribution guidelines request that the `dist` files not be committed, although the master branch seems to include them regardless. I haven't touched them just in case.
