### PR TITLE
Add Tag Reader for FLAC Files

### DIFF
--- a/src/FLACTagContents.js
+++ b/src/FLACTagContents.js
@@ -1,0 +1,78 @@
+const ByteArrayUtils = require('./ByteArrayUtils');
+
+const bin = require('./ByteArrayUtils').bin;
+const getInteger24 = require('./ByteArrayUtils').getInteger24;
+const getInteger32 = require('./ByteArrayUtils').getInteger32;
+
+import type {
+  ByteArray
+} from './FlowTypes';
+
+class FLACTagContents {
+  _blocks: Array<MetadataBlock>;
+
+  constructor(blocks?: Array<MetadataBlock>) {
+    this._blocks = [];
+    this._blocks.push(FLACTagContents.createStreamBlock());
+    this._blocks = this._blocks.concat(blocks || []);
+  }
+
+  toArray(): ByteArray {
+    this._blocks[this._blocks.length - 1].setFinal();
+    return this._blocks.reduce(function(array, block) {
+      return array.concat(block.toArray());
+    }, bin("fLaC"));
+  }
+
+  static createBlock(type: number, data: ByteArray): MetadataBlock {
+    return new MetadataBlock(type, data);
+  }
+
+  static createStreamBlock(): MetadataBlock {
+    let data = [0x00, 0x00, 0x22].concat(Array(34).fill(0x00));
+    return this.createBlock(0, data);
+  }
+
+  static createCommentBlock(...data: Array<Array<string>>): MetadataBlock {
+    let length = 12;
+    let byteArray = [];
+    for (let i = 0; i < data.length; i++) {
+      length += data[i][0].length + data[i][1].length + 5;
+      byteArray = byteArray.concat(getInteger32(data[i][0].length + data[i][1].length + 1).reverse());
+      let entry = data[i][0] + "=" + data[i][1];
+      byteArray = byteArray.concat(bin(entry));
+    }
+    let array = [].concat(getInteger24(length), [0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+      getInteger32(data.length).reverse(), byteArray);
+    return this.createBlock(4, array);
+  }
+
+  static createPictureBlock() {
+    let data = [].concat(getInteger24(45), getInteger32(3), getInteger32(10),
+      bin("image/jpeg"), getInteger32(9), bin("A Picture"), Array(16).fill(0x00),
+      getInteger32(4), bin("data"));
+    return this.createBlock(6, data);
+  }
+}
+
+class MetadataBlock {
+  _data: Array<number>;
+  _final: boolean;
+  _type: number;
+
+  constructor(type: number, data: ByteArray) {
+    this._type = type;
+    this._data = data;
+    this._final = false;
+  }
+
+  setFinal() {
+    this._final = true;
+  }
+
+  toArray() {
+    return [ this._type + (this._final ? 128 : 0) ].concat(this._data);
+  }
+}
+
+module.exports = FLACTagContents;

--- a/src/FLACTagReader.js
+++ b/src/FLACTagReader.js
@@ -8,137 +8,137 @@ const FLAC_HEADER_SIZE = 4;
  * Class representing a MediaTagReader that parses FLAC tags.
  */
 class FLACTagReader extends MediaTagReader {
-    _offset: number;
+  _offset: number;
 
-    /**
-     * Gets the byte range for the tag identifier.
-     *
-     * Because the Vorbis comment block is not guaranteed to be in a specified
-     * location, we can only load the first 4 bytes of the file to confirm it
-     * is a FLAC first.
-     *
-     * @return {ByteRange} The byte range that identifies the tag for a FLAC.
-     */
-    static getTagIdentifierByteRange(): ByteRange {
-        return {
-            offset: 0,
-            length: FLAC_HEADER_SIZE
-        };
-    }
+  /**
+   * Gets the byte range for the tag identifier.
+   *
+   * Because the Vorbis comment block is not guaranteed to be in a specified
+   * location, we can only load the first 4 bytes of the file to confirm it
+   * is a FLAC first.
+   *
+   * @return {ByteRange} The byte range that identifies the tag for a FLAC.
+   */
+  static getTagIdentifierByteRange(): ByteRange {
+    return {
+      offset: 0,
+      length: FLAC_HEADER_SIZE
+    };
+  }
 
-    /**
-     * Determines whether or not this reader can read a certain tag format.
-     *
-     * This checks that the first 4 characters in the file are fLaC, which
-     * according to the FLAC file specification should be the characters that
-     * indicate a FLAC file.
-     *
-     * @return {boolean} True if the header is fLaC, false otherwise.
-     */
-    static canReadTagFormat(tagIdentifier: Array<number>): boolean {
-        var id = String.fromCharCode.apply(String, tagIdentifier.slice(0, 4));
-        return id === 'fLaC';
-    }
+  /**
+   * Determines whether or not this reader can read a certain tag format.
+   *
+   * This checks that the first 4 characters in the file are fLaC, which
+   * according to the FLAC file specification should be the characters that
+   * indicate a FLAC file.
+   *
+   * @return {boolean} True if the header is fLaC, false otherwise.
+   */
+  static canReadTagFormat(tagIdentifier: Array<number>): boolean {
+    var id = String.fromCharCode.apply(String, tagIdentifier.slice(0, 4));
+    return id === 'fLaC';
+  }
 
-    _loadData(mediaFileReader: MediaFileReader, callbacks: LoadCallbackType) {
-        var self = this;
-        mediaFileReader.loadRange([4, 7], {
-            onSuccess: function() {
-                self._loadBlock(mediaFileReader, 4, callbacks);
-            }
-        });
-    }
+  _loadData(mediaFileReader: MediaFileReader, callbacks: LoadCallbackType) {
+    var self = this;
+    mediaFileReader.loadRange([4, 7], {
+      onSuccess: function() {
+        self._loadBlock(mediaFileReader, 4, callbacks);
+      }
+    });
+  }
 
-    /**
-     * Special internal function used to identify the block that holds the Vorbis comment.
-     *
-     * The FLAC specification doesn't specify a specific location for metadata to resign, but
-     * dictates that it may be in one of various blocks located throughout the file. To load the
-     * metadata, we must locate the header first. This can be done by reading the first byte of
-     * each block to determine the block type. After the block type comes a 24 bit integer that stores
-     * the length of the block as big endian. Using this, we locate the block and store the offset for
-     * parsing later.
-     *
-     * More info on the FLAC specification may be found here:
-     * https://xiph.org/flac/format.html
-     * @param {MediaFileReader} mediaFileReader - The MediaFileReader used to parse the file.
-     * @param {number} offset - The offset to start checking the header from.
-     * @param {LoadCallbackType} callbacks - The callback to call once the header has been found.
-     */
-    _loadBlock(
-        mediaFileReader: MediaFileReader,
-        offset: number,
-        callbacks: LoadCallbackType
-    ) {
-        var self = this;
-        var blockHeader = mediaFileReader.getByteAt(offset);
-        var blockSize = mediaFileReader.getInteger24At(offset + 1, true);
-        if (blockHeader !== 4 && blockHeader !== 132) {
-            mediaFileReader.loadRange([offset + 4 + blockSize, offset + 3 + 4 + blockSize], {
-                onSuccess: function() {
-                    self._loadBlock(mediaFileReader, offset + 4 + blockSize, callbacks);
-                }
-            });
-        } else {
-            var offsetMetadata = offset + 4;
-            mediaFileReader.loadRange([offsetMetadata, offsetMetadata + blockSize], {
-                onSuccess: function() {
-                    self._offset = offsetMetadata;
-                    callbacks.onSuccess();
-                }
-            });
+  /**
+   * Special internal function used to identify the block that holds the Vorbis comment.
+   *
+   * The FLAC specification doesn't specify a specific location for metadata to resign, but
+   * dictates that it may be in one of various blocks located throughout the file. To load the
+   * metadata, we must locate the header first. This can be done by reading the first byte of
+   * each block to determine the block type. After the block type comes a 24 bit integer that stores
+   * the length of the block as big endian. Using this, we locate the block and store the offset for
+   * parsing later.
+   *
+   * More info on the FLAC specification may be found here:
+   * https://xiph.org/flac/format.html
+   * @param {MediaFileReader} mediaFileReader - The MediaFileReader used to parse the file.
+   * @param {number} offset - The offset to start checking the header from.
+   * @param {LoadCallbackType} callbacks - The callback to call once the header has been found.
+   */
+  _loadBlock(
+    mediaFileReader: MediaFileReader,
+    offset: number,
+    callbacks: LoadCallbackType
+  ) {
+    var self = this;
+    var blockHeader = mediaFileReader.getByteAt(offset);
+    var blockSize = mediaFileReader.getInteger24At(offset + 1, true);
+    if (blockHeader !== 4 && blockHeader !== 132) {
+      mediaFileReader.loadRange([offset + 4 + blockSize, offset + 3 + 4 + blockSize], {
+        onSuccess: function() {
+          self._loadBlock(mediaFileReader, offset + 4 + blockSize, callbacks);
         }
+      });
+    } else {
+      var offsetMetadata = offset + 4;
+      mediaFileReader.loadRange([offsetMetadata, offsetMetadata + blockSize], {
+        onSuccess: function() {
+          self._offset = offsetMetadata;
+          callbacks.onSuccess();
+        }
+      });
+    }
+  }
+
+  /**
+   * Parses the data and returns the tags.
+   * @param {MediaFileReader} data - The MediaFileReader to parse the file with.
+   * @param {Array<string>} [tags] - Optional tags to also be retrieved from the file.
+   * @return {TagType} - An object containing the tag information for the file.
+   */
+  _parseData(data: MediaFileReader, tags: ?Array<string>): TagType {
+    var string = data.getLongAt(this._offset, false);
+    var offsetVendor = this._offset + 4;
+    var vendor = data.getStringWithCharsetAt(offsetVendor, string, "utf-8").toString();
+    var offsetList = offsetVendor + string;
+    var length = data.getLongAt(offsetList, false);
+    var dataOffset = offsetList + 4;
+    var title, artist, album, track, genre, picture;
+    for (let i = 0; i < length; i++) {
+      let dataLength = data.getLongAt(dataOffset, false);
+      let s = data.getStringWithCharsetAt(dataOffset + 4, dataLength, "utf-8").toString();
+      let d = s.indexOf("=");
+      let split = [s.slice(0, d), s.slice(d + 1)];
+      switch (split[0]) {
+        case "TITLE":
+          title = split[1]
+        case "ARTIST":
+          artist = split[1]
+        case "ALBUM":
+          album = split[1]
+        case "TRACKNUMBER":
+          track = split[1]
+        case "GENRE":
+          genre = split[1]
+      }
+      dataOffset += 4 + dataLength;
     }
 
-    /**
-     * Parses the data and returns the tags.
-     * @param {MediaFileReader} data - The MediaFileReader to parse the file with.
-     * @param {Array<string>} [tags] - Optional tags to also be retrieved from the file.
-     * @return {TagType} - An object containing the tag information for the file.
-     */
-    _parseData(data: MediaFileReader, tags: ?Array<string>): TagType {
-        var string = data.getLongAt(this._offset, false);
-        var offsetVendor = this._offset + 4;
-        var vendor = data.getStringWithCharsetAt(offsetVendor, string, "utf-8").toString();
-        var offsetList = offsetVendor + string;
-        var length = data.getLongAt(offsetList, false);
-        var dataOffset = offsetList + 4;
-        var title, artist, album, track, genre, picture;
-        for (let i = 0; i < length; i++) {
-            let dataLength = data.getLongAt(dataOffset, false);
-            let s = data.getStringWithCharsetAt(dataOffset + 4, dataLength, "utf-8").toString();
-            let d = s.indexOf("=");
-            let split = [s.slice(0, d), s.slice(d + 1)];
-            switch (split[0]) {
-                case "TITLE":
-                    title = split[1]
-                case "ARTIST":
-                    artist = split[1]
-                case "ALBUM":
-                    album = split[1]
-                case "TRACKNUMBER":
-                    track = split[1]
-                case "GENRE":
-                    genre = split[1]
-            }
-            dataOffset += 4 + dataLength;
-        }
 
-
-        var tag = {
-            type: "VorbisComment",
-            version: "1",
-            tags: {
-                "title": title,
-                "artist": artist,
-                "album": album,
-                "track": track,
-                "genre": genre,
-                "picture": picture
-            }
-        }
-        return tag;
+    var tag = {
+      type: "VorbisComment",
+      version: "1",
+      tags: {
+        "title": title,
+        "artist": artist,
+        "album": album,
+        "track": track,
+        "genre": genre,
+        "picture": picture
+      }
     }
+    return tag;
+  }
 }
 
 module.exports = FLACTagReader;

--- a/src/FLACTagReader.js
+++ b/src/FLACTagReader.js
@@ -1,0 +1,144 @@
+var MediaTagReader = require('./MediaTagReader');
+
+const FLAC_HEADER_SIZE = 4;
+
+
+
+/**
+ * Class representing a MediaTagReader that parses FLAC tags.
+ */
+class FLACTagReader extends MediaTagReader {
+    _offset: number;
+
+    /**
+     * Gets the byte range for the tag identifier.
+     *
+     * Because the Vorbis comment block is not guaranteed to be in a specified
+     * location, we can only load the first 4 bytes of the file to confirm it
+     * is a FLAC first.
+     *
+     * @return {ByteRange} The byte range that identifies the tag for a FLAC.
+     */
+    static getTagIdentifierByteRange(): ByteRange {
+        return {
+            offset: 0,
+            length: FLAC_HEADER_SIZE
+        };
+    }
+
+    /**
+     * Determines whether or not this reader can read a certain tag format.
+     *
+     * This checks that the first 4 characters in the file are fLaC, which
+     * according to the FLAC file specification should be the characters that
+     * indicate a FLAC file.
+     *
+     * @return {boolean} True if the header is fLaC, false otherwise.
+     */
+    static canReadTagFormat(tagIdentifier: Array<number>): boolean {
+        var id = String.fromCharCode.apply(String, tagIdentifier.slice(0, 4));
+        return id === 'fLaC';
+    }
+
+    _loadData(mediaFileReader: MediaFileReader, callbacks: LoadCallbackType) {
+        var self = this;
+        mediaFileReader.loadRange([4, 7], {
+            onSuccess: function() {
+                self._loadBlock(mediaFileReader, 4, callbacks);
+            }
+        });
+    }
+
+    /**
+     * Special internal function used to identify the block that holds the Vorbis comment.
+     *
+     * The FLAC specification doesn't specify a specific location for metadata to resign, but
+     * dictates that it may be in one of various blocks located throughout the file. To load the
+     * metadata, we must locate the header first. This can be done by reading the first byte of
+     * each block to determine the block type. After the block type comes a 24 bit integer that stores
+     * the length of the block as big endian. Using this, we locate the block and store the offset for
+     * parsing later.
+     *
+     * More info on the FLAC specification may be found here:
+     * https://xiph.org/flac/format.html
+     * @param {MediaFileReader} mediaFileReader - The MediaFileReader used to parse the file.
+     * @param {number} offset - The offset to start checking the header from.
+     * @param {LoadCallbackType} callbacks - The callback to call once the header has been found.
+     */
+    _loadBlock(
+        mediaFileReader: MediaFileReader,
+        offset: number,
+        callbacks: LoadCallbackType
+    ) {
+        var self = this;
+        var blockHeader = mediaFileReader.getByteAt(offset);
+        var blockSize = mediaFileReader.getInteger24At(offset + 1, true);
+        if (blockHeader !== 4 && blockHeader !== 132) {
+            mediaFileReader.loadRange([offset + 4 + blockSize, offset + 3 + 4 + blockSize], {
+                onSuccess: function() {
+                    self._loadBlock(mediaFileReader, offset + 4 + blockSize, callbacks);
+                }
+            });
+        } else {
+            var offsetMetadata = offset + 4;
+            mediaFileReader.loadRange([offsetMetadata, offsetMetadata + blockSize], {
+                onSuccess: function() {
+                    self._offset = offsetMetadata;
+                    callbacks.onSuccess();
+                }
+            });
+        }
+    }
+
+    /**
+     * Parses the data and returns the tags.
+     * @param {MediaFileReader} data - The MediaFileReader to parse the file with.
+     * @param {Array<string>} [tags] - Optional tags to also be retrieved from the file.
+     * @return {TagType} - An object containing the tag information for the file.
+     */
+    _parseData(data: MediaFileReader, tags: ?Array<string>): TagType {
+        var string = data.getLongAt(this._offset, false);
+        var offsetVendor = this._offset + 4;
+        var vendor = data.getStringWithCharsetAt(offsetVendor, string, "utf-8").toString();
+        var offsetList = offsetVendor + string;
+        var length = data.getLongAt(offsetList, false);
+        var dataOffset = offsetList + 4;
+        var title, artist, album, track, genre, picture;
+        for (let i = 0; i < length; i++) {
+            let dataLength = data.getLongAt(dataOffset, false);
+            let s = data.getStringWithCharsetAt(dataOffset + 4, dataLength, "utf-8").toString();
+            let d = s.indexOf("=");
+            let split = [s.slice(0, d), s.slice(d + 1)];
+            switch (split[0]) {
+                case "TITLE":
+                    title = split[1]
+                case "ARTIST":
+                    artist = split[1]
+                case "ALBUM":
+                    album = split[1]
+                case "TRACKNUMBER":
+                    track = split[1]
+                case "GENRE":
+                    genre = split[1]
+            }
+            dataOffset += 4 + dataLength;
+        }
+
+
+        var tag = {
+            type: "VorbisComment",
+            version: "1",
+            tags: {
+                "title": title,
+                "artist": artist,
+                "album": album,
+                "track": track,
+                "genre": genre,
+                "picture": picture
+            }
+        }
+        return tag;
+    }
+}
+
+module.exports = FLACTagReader;

--- a/src/FLACTagReader.js
+++ b/src/FLACTagReader.js
@@ -1,7 +1,27 @@
 var MediaTagReader = require('./MediaTagReader');
 
+/* The first 4 bytes of a FLAC file describes the header for the file. If these
+ * bytes respectively read "fLaC", we can determine it is a FLAC file.
+ */
 const FLAC_HEADER_SIZE = 4;
 
+/* FLAC metadata is stored in blocks containing data ranging from STREAMINFO to
+ * VORBIS_COMMENT, which is what we want to work with.
+ *
+ * Each metadata header is 4 bytes long, with the first byte determining whether
+ * it is the last metadata block before the audio data and what the block type is.
+ * This first byte can further be split into 8 bits, with the first bit being the
+ * last-metadata-block flag, and the last three bits being the block type.
+ *
+ * Since the specification states that the decimal value for a VORBIS_COMMENT block
+ * type is 4, the two possibilities for the comment block header values are:
+ * - 00000100 (Not a last metadata comment block, value of 4)
+ * - 10000100 (A last metadata comment block, value of 132)
+ *
+ * All values for METADATA_BLOCK_HEADER can be found here.
+ * https://xiph.org/flac/format.html#metadata_block_header
+ */
+const COMMENT_HEADERS = [4, 132];
 
 
 /**
@@ -40,6 +60,17 @@ class FLACTagReader extends MediaTagReader {
     return id === 'fLaC';
   }
 
+  /**
+   * Function called to load the data from the file.
+   *
+   * To begin processing the blocks, the next 4 bytes after the initial 4 bytes
+   * (bytes 4 through 7) are loaded. From there, the rest of the loading process
+   * is passed on to the _loadBlock function, which will handle the rest of the
+   * parsing for the metadata blocks.
+   *
+   * @param {MediaFileReader} mediaFileReader - The MediaFileReader used to parse the file.
+   * @param {LoadCallbackType} callbacks - The callback to call once _loadData is completed.
+   */
   _loadData(mediaFileReader: MediaFileReader, callbacks: LoadCallbackType) {
     var self = this;
     mediaFileReader.loadRange([4, 7], {
@@ -71,15 +102,37 @@ class FLACTagReader extends MediaTagReader {
     callbacks: LoadCallbackType
   ) {
     var self = this;
+    /* As mentioned above, this first byte is loaded to see what metadata type
+     * this block represents.
+     */
     var blockHeader = mediaFileReader.getByteAt(offset);
+    /* The last three bytes (integer 24) contain a value representing the length
+     * of the following metadata block. The 1 is added in order to shift the offset
+     * by one to get the last three bytes in the block header.
+     */
     var blockSize = mediaFileReader.getInteger24At(offset + 1, true);
-    if (blockHeader !== 4 && blockHeader !== 132) {
-      mediaFileReader.loadRange([offset + 4 + blockSize, offset + 3 + 4 + blockSize], {
+    /* This conditional checks if blockHeader (the byte retrieved representing the
+     * type of the header) is not the header we are looking for.
+     *
+     * If that is not true, the block is skipped over and the next range is loaded:
+     * - offset + 4 + blockSize adds 4 to skip over the initial metadata header and
+     * blockSize to skip over the block overall, placing it at the head of the next
+     * metadata header.
+     * - offset + 4 + 4 + blockSize does the same thing as the previous block with
+     * the exception of adding another 4 bytes to move it to the end of the new metadata
+     * header.
+     */
+    if (COMMENT_HEADERS.indexOf(blockHeader) === -1) {
+      mediaFileReader.loadRange([offset + 4 + blockSize, offset + 4 + 4 + blockSize], {
         onSuccess: function() {
           self._loadBlock(mediaFileReader, offset + 4 + blockSize, callbacks);
         }
       });
     } else {
+      /* 4 is added to offset to move it to the head of the actual metadata.
+       * The range starting from offsetMatadata (the beginning of the block)
+       * and offsetMetadata + blockSize (the end of the block) is loaded.
+       */
       var offsetMetadata = offset + 4;
       mediaFileReader.loadRange([offsetMetadata, offsetMetadata + blockSize], {
         onSuccess: function() {
@@ -92,34 +145,68 @@ class FLACTagReader extends MediaTagReader {
 
   /**
    * Parses the data and returns the tags.
+   *
+   * This is an overview of the VorbisComment format and what this function attempts to
+   * retrieve:
+   * - First 4 bytes: a long that contains the length of the vendor string.
+   * - Next n bytes: the vendor string encoded in UTF-8.
+   * - Next 4 bytes: a long representing how many comments are in this block
+   * For each comment that exists:
+   * - First 4 bytes: a long representing the length of the comment
+   * - Next n bytes: the comment encoded in UTF-8.
+   * The comment string will usually appear in a format similar to:
+   * ARTIST=me
+   *
+   * Note that the longs and integers in this block are encoded in little endian
+   * as opposed to big endian for the rest of the FLAC spec.
    * @param {MediaFileReader} data - The MediaFileReader to parse the file with.
    * @param {Array<string>} [tags] - Optional tags to also be retrieved from the file.
    * @return {TagType} - An object containing the tag information for the file.
    */
   _parseData(data: MediaFileReader, tags: ?Array<string>): TagType {
-    var string = data.getLongAt(this._offset, false);
+    var vendorLength = data.getLongAt(this._offset, false);
     var offsetVendor = this._offset + 4;
-    var vendor = data.getStringWithCharsetAt(offsetVendor, string, "utf-8").toString();
-    var offsetList = offsetVendor + string;
-    var length = data.getLongAt(offsetList, false);
+    /* This line is able to retrieve the vendor string that the VorbisComment block
+     * contains. However, it is not part of the tags that JSMediaTags normally retrieves,
+     * and is therefore commented out.
+     */
+    // var vendor = data.getStringWithCharsetAt(offsetVendor, vendorLength, "utf-8").toString();
+    var offsetList = vendorLength + offsetVendor;
+    /* To get the metadata from the block, we first get the long that contains the
+     * number of actual comment values that are existent within the block.
+     *
+     * As we loop through all of the comment blocks, we get the data length in order to
+     * get the right size string, and then determine which category that string falls under.
+     * The dataOffset variable is constantly updated so that it is at the beginning of the
+     * comment that is currently being parsed.
+     *
+     * Additions of 4 here are used to move the offset past the first 4 bytes which only contain
+     * the length of the comment.
+     */
+    var numComments = data.getLongAt(offsetList, false);
     var dataOffset = offsetList + 4;
     var title, artist, album, track, genre, picture;
-    for (let i = 0; i < length; i++) {
+    for (let i = 0; i < numComments; i++) {
       let dataLength = data.getLongAt(dataOffset, false);
       let s = data.getStringWithCharsetAt(dataOffset + 4, dataLength, "utf-8").toString();
       let d = s.indexOf("=");
       let split = [s.slice(0, d), s.slice(d + 1)];
       switch (split[0]) {
         case "TITLE":
-          title = split[1]
+          title = split[1];
+          break;
         case "ARTIST":
-          artist = split[1]
+          artist = split[1];
+          break;
         case "ALBUM":
-          album = split[1]
+          album = split[1];
+          break;
         case "TRACKNUMBER":
-          track = split[1]
+          track = split[1];
+          break;
         case "GENRE":
-          genre = split[1]
+          genre = split[1];
+          break;
       }
       dataOffset += 4 + dataLength;
     }

--- a/src/__tests__/FLACTagReader-test.js
+++ b/src/__tests__/FLACTagReader-test.js
@@ -28,8 +28,7 @@ describe("FLACTagReader", function() {
       });
       jest.runAllTimers();
     }).then(function(tag) {
-      console.log(tag);
-      expect(tag.type).toBe("VorbisComment");
+      expect(tag.type).toBe("FLAC");
       expect(tag.version).toBe("1");
     });
   });
@@ -45,9 +44,20 @@ describe("FLACTagReader", function() {
       var tags = tag.tags;
       expect(tags.title).toBe("A Title");
     });
-  })
+  });
 
-  it("reads an image tag")
+  it("reads an image tag", function() {
+    return new Promise(function(resolve, reject) {
+      tagReader.read({
+        onSuccess: resolve,
+        onFailure: reject
+      });
+      jest.runAllTimers();
+    }).then(function(tag) {
+      var tags = tag.tags;
+      expect(tags.picture.description).toBe("A Picture");
+    });
+  });
 
   it("reads all tags", function() {
     return new Promise(function(resolve, reject) {
@@ -63,6 +73,20 @@ describe("FLACTagReader", function() {
       expect(tags.album).toBeTruthy();
       expect(tags.track).toBeTruthy();
       expect(tags.picture).toBeTruthy();
+    });
+  });
+  it("calls failure callback if file doesn't have comments", function() {
+    var flacFileEmpty = new FLACTagContents();
+    var fileReaderEmpty = new ArrayFileReader(flacFileEmpty.toArray());
+    var tagReaderEmpty = new FLACTagReader(fileReaderEmpty);
+    return new Promise(function(resolve, reject) {
+      tagReaderEmpty.read({
+        onSuccess: resolve,
+        onError: reject
+      });
+      jest.runAllTimers();
+    }).catch(function(error) {
+      expect(error.type).toBe("loadData");
     });
   });
 });

--- a/src/__tests__/FLACTagReader-test.js
+++ b/src/__tests__/FLACTagReader-test.js
@@ -1,0 +1,68 @@
+jest.autoMockOff();
+
+const ArrayFileReader = require('../ArrayFileReader');
+const FLACTagContents = require('../FLACTagContents');
+const FLACTagReader = require('../FLACTagReader');
+
+describe("FLACTagReader", function() {
+  var flacFileContents = new FLACTagContents([FLACTagContents.createCommentBlock(
+    ["TITLE", "A Title"],
+    ["ARTIST", "An Artist"],
+    ["ALBUM", "An Album"],
+    ["TRACKNUMBER", "1"],
+    ["GENRE", "A Genre"]
+  ), FLACTagContents.createPictureBlock()]);
+  var mediaFileReader;
+  var tagReader;
+
+  beforeEach(function() {
+    mediaFileReader = new ArrayFileReader(flacFileContents.toArray());
+    tagReader = new FLACTagReader(mediaFileReader);
+  });
+
+  it("reads the tag type", function () {
+    return new Promise(function(resolve, reject) {
+      tagReader.read({
+        onSuccess: resolve,
+        onFailure: reject
+      });
+      jest.runAllTimers();
+    }).then(function(tag) {
+      console.log(tag);
+      expect(tag.type).toBe("VorbisComment");
+      expect(tag.version).toBe("1");
+    });
+  });
+
+  it("reads a string tag", function() {
+    return new Promise(function(resolve, reject) {
+      tagReader.read({
+        onSuccess: resolve,
+        onFailure: reject
+      });
+      jest.runAllTimers();
+    }).then(function(tag) {
+      var tags = tag.tags;
+      expect(tags.title).toBe("A Title");
+    });
+  })
+
+  it("reads an image tag")
+
+  it("reads all tags", function() {
+    return new Promise(function(resolve, reject) {
+      tagReader.read({
+        onSuccess: resolve,
+        onFailure: reject
+      });
+      jest.runAllTimers();
+    }).then(function(tag) {
+      var tags = tag.tags;
+      expect(tags.title).toBeTruthy();
+      expect(tags.artist).toBeTruthy();
+      expect(tags.album).toBeTruthy();
+      expect(tags.track).toBeTruthy();
+      expect(tags.picture).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
I noticed issue #25 which seems to have been untouched since May 31st, 2016. I figured that since I wanted support for FLAC files anyway, that I would draft this up as a makeshift solution for retrieving tags from FLAC files.

I've left the `jsmediatags.js` file intact as there are still a few issues with the implementation I wrote up:

- A few tag types, such as comment and year, have different implementations in the Vorbis comment format or are not part of the specification altogether.
- The picture tag has not been implemented because it is stored in a different metadata block from the Vorbis comment.
- No testing has been added for this tag reader yet.

Hopefully these can be resolved in future commits.

The specification for the FLAC and Ogg Vorbis formats can be found [here](https://xiph.org/flac/format.html) and [here](https://www.xiph.org/vorbis/doc/v-comment.html). As the two formats are very similar, a small rewrite should be all that's needed to address #25.

Expectations (will be marked off once unit tests are written):
- [x] Should properly identify a FLAC file from the header
- [x] Should properly load regular string metadata (Title, Artist, Album, Genre, Track)
- [x] Should load data regarding the album picture
- [x] Should properly call the error callback if the Vorbis comment does not exist or could not be loaded