### PR TITLE
Update jest and babel-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "babel-plugin-transform-es2015-classes": "~6.6.5",
     "babel-plugin-transform-es2015-block-scoping": "~6.7.1",
     "babel-plugin-transform-class-properties": "~6.6.0",
-    "babel-jest": "~12.0.2",
+    "babel-jest": "~20.0.3",
     "babel-core": "~6.7.7",
     "babel-cli": "~6.7.7",
-    "jest-cli": "~12.0.2",
+    "jest-cli": "~20.0.4",
     "browserify": "~14.4.0",
     "watchify": "~3.7.0",
     "babelify": "~7.3.0",
@@ -63,7 +63,10 @@
   },
   "jest": {
     "rootDir": "./src",
-    "scriptPreprocessor": "../node_modules/babel-jest"
+    "timers": "fake",
+    "transform": {
+      ".js$": "babel-jest"
+    }
   },
   "engines": {
     "node": ">=4.0.0"

--- a/src/__tests__/ArrayFileReader-test.js
+++ b/src/__tests__/ArrayFileReader-test.js
@@ -28,7 +28,7 @@ describe("ArrayFileReader", function() {
     expect(ArrayFileReader.canReadFile(new Blob())).toBe(false);
   });
 
-  pit("should have the right size information", function() {
+  it("should have the right size information", function() {
     return new Promise(function(resolve, reject) {
       fileReader.init(throwOnError(resolve));
       jest.runAllTimers();
@@ -37,7 +37,7 @@ describe("ArrayFileReader", function() {
     });
   });
 
-  pit("should read a byte", function() {
+  it("should read a byte", function() {
     return new Promise(function(resolve, reject) {
       fileReader.loadRange([0, 4], throwOnError(resolve));
       jest.runAllTimers();

--- a/src/__tests__/BlobFileReader-test.js
+++ b/src/__tests__/BlobFileReader-test.js
@@ -27,7 +27,7 @@ describe("BlobFileReader", function() {
     expect(BlobFileReader.canReadFile(new Blob())).toBe(true);
   });
 
-  pit("should have the right size information", function() {
+  it("should have the right size information", function() {
     return new Promise(function(resolve, reject) {
       fileReader.init(throwOnError(resolve));
       jest.runAllTimers();
@@ -36,7 +36,7 @@ describe("BlobFileReader", function() {
     });
   });
 
-  pit("should read a byte", function() {
+  it("should read a byte", function() {
     return new Promise(function(resolve, reject) {
       fileReader.loadRange([0, 4], throwOnError(resolve));
       jest.runAllTimers();
@@ -45,7 +45,7 @@ describe("BlobFileReader", function() {
     });
   });
 
-  pit("should read a byte after loading the same range twice", function() {
+  it("should read a byte after loading the same range twice", function() {
     return new Promise(function(resolve, reject) {
       fileReader.loadRange([0, 4], throwOnError(function() {
         fileReader.loadRange([0, 4], throwOnError(resolve));
@@ -55,7 +55,7 @@ describe("BlobFileReader", function() {
     });
   });
 
-  pit("should not read a byte that hasn't been loaded yet", function() {
+  it("should not read a byte that hasn't been loaded yet", function() {
     return new Promise(function(resolve, reject) {
       fileReader.init(throwOnError(resolve));
       jest.runAllTimers();

--- a/src/__tests__/ID3v1TagReader-test.js
+++ b/src/__tests__/ID3v1TagReader-test.js
@@ -7,7 +7,7 @@ const bin = require('../ByteArrayUtils').bin;
 const pad = require('../ByteArrayUtils').pad;
 
 describe("ID3v1TagReader", function() {
-  pit("reads 1.0 tags", function() {
+  it("reads 1.0 tags", function() {
     var id3ArrayFile = [].concat(
       bin("TAG"),
       pad(bin("Song Title"), 30),
@@ -42,7 +42,7 @@ describe("ID3v1TagReader", function() {
     });
   });
 
-  pit("reads 1.1 tags", function() {
+  it("reads 1.1 tags", function() {
     var id3ArrayFile = [].concat(
       bin("TAG"),
       pad(bin("Song Title"), 30),

--- a/src/__tests__/ID3v2TagReader-test.js
+++ b/src/__tests__/ID3v2TagReader-test.js
@@ -26,7 +26,7 @@ describe("ID3v2TagReader", function() {
     tagReader = new ID3v2TagReader(mediaFileReader);
   });
 
-  pit("reads header", function() {
+  it("reads header", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -51,7 +51,7 @@ describe("ID3v2TagReader", function() {
     });
   });
 
-  pit("loads the entire tag", function() {
+  it("loads the entire tag", function() {
     mediaFileReader.loadRange = jest.genMockFunction().mockImplementation(
       function() {
         return ArrayFileReader.prototype.loadRange.apply(this, arguments);
@@ -71,7 +71,7 @@ describe("ID3v2TagReader", function() {
     });
   });
 
-  pit("reads tags", function() {
+  it("reads tags", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -89,7 +89,7 @@ describe("ID3v2TagReader", function() {
     });
   });
 
-  pit("reads tags as shortcuts", function() {
+  it("reads tags as shortcuts", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -101,7 +101,7 @@ describe("ID3v2TagReader", function() {
     });
   });
 
-  pit("reads all tags when none is specified", function() {
+  it("reads all tags when none is specified", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -114,7 +114,7 @@ describe("ID3v2TagReader", function() {
     });
   });
 
-  pit("reads the specificed tag", function() {
+  it("reads the specificed tag", function() {
     return new Promise(function(resolve, reject) {
       tagReader.setTagsToRead(["TCOM"])
         .read({
@@ -128,7 +128,7 @@ describe("ID3v2TagReader", function() {
     });
   });
 
-  pit("should ignore empty tags", function() {
+  it("should ignore empty tags", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -141,7 +141,7 @@ describe("ID3v2TagReader", function() {
   });
 
   describe("unsynchronisation", function() {
-    pit("reads global unsynchronised content", function() {
+    it("reads global unsynchronised content", function() {
       var id3FileContents =
         new ID3v2TagContents(4, 3)
           .setFlags({
@@ -173,7 +173,7 @@ describe("ID3v2TagReader", function() {
       });
     });
 
-    pit("reads local unsynchronised content", function() {
+    it("reads local unsynchronised content", function() {
       var id3FileContents =
         new ID3v2TagContents(4, 3)
           .addFrame("TIT2", [].concat(
@@ -205,7 +205,7 @@ describe("ID3v2TagReader", function() {
       });
     });
 
-    pit("reads unsynchronised content with data length indicator", function() {
+    it("reads unsynchronised content with data length indicator", function() {
       var id3FileContents =
         new ID3v2TagContents(4, 3)
           .addFrame("TIT2", [].concat(
@@ -240,7 +240,7 @@ describe("ID3v2TagReader", function() {
     });
   });
 
-  pit("should process frames with no content", function() {
+  it("should process frames with no content", function() {
     var id3FileContents =
       new ID3v2TagContents(4, 3)
         .addFrame("WOAF") // empty frame contents
@@ -262,7 +262,7 @@ describe("ID3v2TagReader", function() {
     });
   });
 
-  pit("should correctly assign shortcuts to when there are multiple instances of the same frame", function() {
+  it("should correctly assign shortcuts to when there are multiple instances of the same frame", function() {
     var id3FileContents =
       new ID3v2TagContents(4, 3)
         .addFrame("TIT2", [].concat(

--- a/src/__tests__/MP4TagReader-test.js
+++ b/src/__tests__/MP4TagReader-test.js
@@ -58,7 +58,7 @@ describe("MP4TagReader", function() {
     expect(canReadISOM).toBeTruthy();
   });
 
-  pit("reads the type and version", function() {
+  it("reads the type and version", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -71,7 +71,7 @@ describe("MP4TagReader", function() {
     });
   });
 
-  pit("reads string tag", function() {
+  it("reads string tag", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -84,7 +84,7 @@ describe("MP4TagReader", function() {
     });
   });
 
-  pit("reads uint8 tag", function() {
+  it("reads uint8 tag", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -97,7 +97,7 @@ describe("MP4TagReader", function() {
     });
   });
 
-  pit("reads jpeg tag", function() {
+  it("reads jpeg tag", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -112,7 +112,7 @@ describe("MP4TagReader", function() {
     });
   });
 
-  pit("reads multiple int tags", function() {
+  it("reads multiple int tags", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -128,7 +128,7 @@ describe("MP4TagReader", function() {
     });
   });
 
-  pit("reads all tags", function() {
+  it("reads all tags", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -147,7 +147,7 @@ describe("MP4TagReader", function() {
     });
   });
 
-  pit("creates shorcuts", function() {
+  it("creates shorcuts", function() {
     return new Promise(function(resolve, reject) {
       tagReader.read({
         onSuccess: resolve,
@@ -161,7 +161,7 @@ describe("MP4TagReader", function() {
     });
   });
 
-  pit("reads the specificed tag", function() {
+  it("reads the specificed tag", function() {
     return new Promise(function(resolve, reject) {
       tagReader.setTagsToRead(["©cmt"])
         .read({
@@ -175,7 +175,7 @@ describe("MP4TagReader", function() {
     });
   });
 
-  pit("reads the specificed shortcut tag", function() {
+  it("reads the specificed shortcut tag", function() {
     return new Promise(function(resolve, reject) {
       tagReader.setTagsToRead(["title"])
         .read({
@@ -187,7 +187,7 @@ describe("MP4TagReader", function() {
       expect(Object.keys(tag.tags)).toContain("title");
     });
 
-    pit("reads jpeg tag despite uint8 type", function() {
+    it("reads jpeg tag despite uint8 type", function() {
       var mp4FileContents = createMP4FileContents([
         MP4TagContents.createMetadataAtom("covr", "uint8", [0x01, 0x02, 0x03])
       ]);

--- a/src/__tests__/MediaTagReader-test.js
+++ b/src/__tests__/MediaTagReader-test.js
@@ -19,7 +19,7 @@ describe("MediaTagReader", function() {
     mediaTagReader = new MediaTagReader(mediaFileReader);
   });
 
-  pit("can read the data given by _parseData", function() {
+  it("can read the data given by _parseData", function() {
     var expectedTags = {};
     mediaTagReader._loadData =
       jest.genMockFunction().mockImplementation(function(_, callbacks) {
@@ -40,7 +40,7 @@ describe("MediaTagReader", function() {
     });
   });
 
-  pit("should _loadData when it needs to be read", function() {
+  it("should _loadData when it needs to be read", function() {
     mediaTagReader._loadData = jest.genMockFunction().mockImplementation(
       function(localMediaFileReader, callbacks) {
         expect(localMediaFileReader).toBe(mediaFileReader);

--- a/src/__tests__/NodeFileReader-test.js
+++ b/src/__tests__/NodeFileReader-test.js
@@ -21,7 +21,7 @@ describe("NodeFileReader", function() {
     expect(NodeFileReader.canReadFile(new Blob())).toBe(false);
   });
 
-  pit("should have the right size information", function() {
+  it("should have the right size information", function() {
     fileReader = new NodeFileReader("fakefile");
 
     return new Promise(function(resolve, reject) {
@@ -31,7 +31,7 @@ describe("NodeFileReader", function() {
     });
   });
 
-  pit("should read a byte", function() {
+  it("should read a byte", function() {
     fileReader = new NodeFileReader("fakefile");
 
     return new Promise(function(resolve, reject) {
@@ -41,7 +41,7 @@ describe("NodeFileReader", function() {
     });
   });
 
-  pit("should read a byte after loading the same range twice", function() {
+  it("should read a byte after loading the same range twice", function() {
     fileReader = new NodeFileReader("fakefile");
 
     return new Promise(function(resolve, reject) {
@@ -56,7 +56,7 @@ describe("NodeFileReader", function() {
     });
   });
 
-  pit("should not read a byte that hasn't been loaded yet", function() {
+  it("should not read a byte that hasn't been loaded yet", function() {
     fileReader = new NodeFileReader("fakefile");
 
     return new Promise(function(resolve, reject) {
@@ -68,7 +68,7 @@ describe("NodeFileReader", function() {
     });
   });
 
-  pit("should not read a file that does not exist", function() {
+  it("should not read a file that does not exist", function() {
     fileReader = new NodeFileReader("doesnt-exist");
 
     return new Promise(function(resolve, reject) {

--- a/src/__tests__/XhrFileReader-test.js
+++ b/src/__tests__/XhrFileReader-test.js
@@ -28,6 +28,7 @@ describe("XhrFileReader", function() {
   var fileReader;
 
   beforeEach(function() {
+    jest.resetModules();
     require('xhr2').__setMockUrls({
       "http://www.example.fakedomain/music.mp3": "This is a simple file",
       "http://www.example.fakedomain/big-file.mp3": new Array(100).join("This is a simple file"),
@@ -69,7 +70,7 @@ describe("XhrFileReader", function() {
         });
       });
 
-      pit("should have the right size information", function() {
+      it("should have the right size information", function() {
         return new Promise(function(resolve, reject) {
           fileReader.init(throwOnError(resolve));
           jest.runAllTimers();
@@ -78,7 +79,7 @@ describe("XhrFileReader", function() {
         });
       });
 
-      pit("should have the right size information for files bigger than the first range request", function() {
+      it("should have the right size information for files bigger than the first range request", function() {
         fileReader = new XhrFileReader("http://www.example.fakedomain/big-file.mp3");
         return new Promise(function(resolve, reject) {
           fileReader.init(throwOnError(resolve));
@@ -88,7 +89,7 @@ describe("XhrFileReader", function() {
         });
       });
 
-      pit("should have the right size information when range not supported", function() {
+      it("should have the right size information when range not supported", function() {
         fileReader = new XhrFileReader("http://www.example.fakedomain/range-not-supported.mp3");
         return new Promise(function(resolve, reject) {
           fileReader.init(throwOnError(resolve));
@@ -98,7 +99,7 @@ describe("XhrFileReader", function() {
         });
       });
 
-      pit("should have the right size information when content length is unknown", function() {
+      it("should have the right size information when content length is unknown", function() {
         fileReader = new XhrFileReader("http://www.example.fakedomain/unknown-length.mp3");
         return new Promise(function(resolve, reject) {
           fileReader.init(throwOnError(resolve));
@@ -108,7 +109,7 @@ describe("XhrFileReader", function() {
         });
       });
 
-      pit("should have the right size information when range is supported", function() {
+      it("should have the right size information when range is supported", function() {
         fileReader = new XhrFileReader("http://www.example.fakedomain/range-supported.mp3");
         return new Promise(function(resolve, reject) {
           fileReader.init(throwOnError(resolve));
@@ -123,7 +124,7 @@ describe("XhrFileReader", function() {
   describeFileSizeTests(true /*GET*/);
   describeFileSizeTests(false /*HEAD*/);
 
-  pit("should not fetch the same data twice", function() {
+  it("should not fetch the same data twice", function() {
     return new Promise(function(resolve, reject) {
       fileReader.loadRange([0, 4], throwOnError(function() {
         fileReader.loadRange([0, 4], throwOnError(resolve));
@@ -134,7 +135,7 @@ describe("XhrFileReader", function() {
     });
   });
 
-  pit("should read a byte", function() {
+  it("should read a byte", function() {
     return new Promise(function(resolve, reject) {
       fileReader.loadRange([0, 4], throwOnError(resolve));
       jest.runAllTimers();
@@ -143,7 +144,7 @@ describe("XhrFileReader", function() {
     });
   });
 
-  pit("should read a byte after loading the same range twice", function() {
+  it("should read a byte after loading the same range twice", function() {
     return new Promise(function(resolve, reject) {
       fileReader.loadRange([0, 4], throwOnError(function() {
         fileReader.loadRange([0, 4], throwOnError(resolve));
@@ -154,7 +155,7 @@ describe("XhrFileReader", function() {
     });
   });
 
-  pit("should not read a byte that hasn't been loaded yet", function() {
+  it("should not read a byte that hasn't been loaded yet", function() {
     return new Promise(function(resolve, reject) {
       fileReader.init(throwOnError(resolve));
       jest.runAllTimers();
@@ -165,7 +166,7 @@ describe("XhrFileReader", function() {
     });
   });
 
-  pit("should not read a file that does not exist", function() {
+  it("should not read a file that does not exist", function() {
     fileReader = new XhrFileReader("http://www.example.fakedomain/fail.mp3");
 
     return new Promise(function(resolve, reject) {
@@ -180,7 +181,7 @@ describe("XhrFileReader", function() {
     });
   });
 
-  pit("should fetch in multples of 1K", function() {
+  it("should fetch in multples of 1K", function() {
     return new Promise(function(resolve, reject) {
       fileReader._size=2000;
       fileReader.loadRange([0, 4], throwOnError(resolve));
@@ -190,7 +191,7 @@ describe("XhrFileReader", function() {
     });
   });
 
-  pit("should not fetch more than max file size", function() {
+  it("should not fetch more than max file size", function() {
     return new Promise(function(resolve, reject) {
       fileReader._size=10;
       fileReader.loadRange([0, 4], throwOnError(resolve));
@@ -200,7 +201,7 @@ describe("XhrFileReader", function() {
     });
   });
 
-  pit("should not use disallowed headers", function() {
+  it("should not use disallowed headers", function() {
     return new Promise(function(resolve, reject) {
       XhrFileReader.setConfig({
         disallowedXhrHeaders: ["If-Modified-Since"]
@@ -215,7 +216,7 @@ describe("XhrFileReader", function() {
     });
   });
 
-  pit("should not rely on content-length when range is not supported", function() {
+  it("should not rely on content-length when range is not supported", function() {
     return new Promise(function(resolve, reject) {
       XhrFileReader.setConfig({
         avoidHeadRequests: true
@@ -228,7 +229,7 @@ describe("XhrFileReader", function() {
     });
   });
 
-  pit("should timeout if request takes too much time", function() {
+  it("should timeout if request takes too much time", function() {
     fileReader = new XhrFileReader("http://www.example.fakedomain/timeout");
     XhrFileReader.setConfig({
       timeoutInSec: 0.2

--- a/src/__tests__/jsmediatags-test.js
+++ b/src/__tests__/jsmediatags-test.js
@@ -1,4 +1,5 @@
 jest
+  .enableAutomock()
   .dontMock("../jsmediatags.js")
   .dontMock("../ByteArrayUtils.js");
 
@@ -47,7 +48,7 @@ describe("jsmediatags", function() {
     ID3v2TagReader.prototype.setTagsToRead = jest.genMockFunction().mockReturnThis();
   });
 
-  pit("should read tags with the shortcut function", function() {
+  it("should read tags with the shortcut function", function() {
     NodeFileReader.canReadFile.mockReturnValue(true);
     ID3v2TagReader.canReadTagFormat.mockReturnValue(true);
     ID3v2TagReader.prototype.read = jest.genMockFunction()
@@ -103,7 +104,7 @@ describe("jsmediatags", function() {
   });
 
   describe("tag readers", function() {
-    pit("should use the given tag reader", function() {
+    it("should use the given tag reader", function() {
       var MockTagReader = jest.genMockFunction();
 
       return new Promise(function(resolve, reject) {
@@ -116,7 +117,7 @@ describe("jsmediatags", function() {
       });
     });
 
-    pit("should use the tag reader that is able to read the tags", function() {
+    it("should use the tag reader that is able to read the tags", function() {
       var MockTagReader = jest.genMockFunction();
       jsmediatags.Config.addTagReader(MockTagReader);
 
@@ -137,7 +138,7 @@ describe("jsmediatags", function() {
       });
     });
 
-    pit("should fail if no tag reader is found", function() {
+    it("should fail if no tag reader is found", function() {
       ID3v2TagReader.canReadTagFormat.mockReturnValue(false);
       return new Promise(function(resolve, reject) {
         var reader = new jsmediatags.Reader();
@@ -146,7 +147,7 @@ describe("jsmediatags", function() {
       });
     });
 
-    pit("should load the super set range of all tag reader ranges", function() {
+    it("should load the super set range of all tag reader ranges", function() {
       var MockTagReader = jest.genMockFunction();
       jsmediatags.Config.addTagReader(MockTagReader);
 
@@ -170,7 +171,7 @@ describe("jsmediatags", function() {
       });
     });
 
-    pit("should not load the entire file if two tag loaders require start and end ranges for tag identifier", function() {
+    it("should not load the entire file if two tag loaders require start and end ranges for tag identifier", function() {
       var fileReader = new NodeFileReader();
       var MockTagReader = jest.genMockFunction();
       jsmediatags.Config.addTagReader(MockTagReader);


### PR DESCRIPTION
I started to dive in the code looking for a way to contribute so I updated `jest` 😀

- Enable automock in `jsmediatags-test.js` https://facebook.github.io/jest/blog/2016/09/01/jest-15.html#disabled-automocking
- Configure `fake` timers https://facebook.github.io/jest/blog/2016/09/01/jest-15.html#real-vs-fake-timers
- Reset module cache explictly in `XhrFileReader-test.js` https://facebook.github.io/jest/blog/2016/09/01/jest-15.html#module-registry-persistence
- Replace `scriptPreprocessor ` with `transform` https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-1700
- Replace `pit` with `it` https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-1800
