### PR TITLE
change to XhrReader canReadFile test

### DIFF
--- a/src/XhrFileReader.js
+++ b/src/XhrFileReader.js
@@ -37,7 +37,7 @@ class XhrFileReader extends MediaFileReader {
   static canReadFile(file: any): boolean {
     return (
       typeof file === 'string' &&
-      /^[a-z]+:\/\//i.test(file)
+      new RegExp("(http(s?):)|([/|.|\w|\s])*\.(?:mp3|mp4)").test(file)
     );
   }
 


### PR DESCRIPTION
short URL’s were not working  eg: jsmediatags.read("./track.mp3”)  and tests for file extension.