### PR TITLE
Fix invalid ArrayBuffer -> Number cast

### DIFF
--- a/src/BlobFileReader.js
+++ b/src/BlobFileReader.js
@@ -42,7 +42,7 @@ class BlobFileReader extends MediaFileReader {
     var browserFileReader = new FileReader();
 
     browserFileReader.onloadend = function(event) {
-      var intArray = new Uint8Array(Number(browserFileReader.result));
+      var intArray = new Uint8Array(browserFileReader.result);
       self._fileData.addData(range[0], intArray);
       callbacks.onSuccess();
     };


### PR DESCRIPTION
Fixes #77.

I ran `npm test` before my changes and got 7 failing tests. I'm not sure if it's because I'm running on Windows?

I also ran Flow after my change and got a warning, but I've never used Flow and don't know how to fix that one.