### PR TITLE
React Native Support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "presets": ["react-native"],
   "plugins": [
     "babel-plugin-transform-es2015-modules-commonjs",
     "transform-class-properties",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "xhr2": "^0.1.4"
   },
   "optionalPeerDependencies": {
+    "buffer": "^5.0.8",
     "react-native-fs": "^2.9.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "homepage": "https://github.com/aadsm/jsmediatags#readme",
   "react-native": {
-    "fs": false
+    "fs": false,
+    "./NodeFileReader": false
   },
   "dependencies": {
     "xhr2": "^0.1.4"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
   "dependencies": {
     "xhr2": "^0.1.4"
   },
+  "optionalPeerDependencies": {
+    "react-native-fs": "^2.9.2"
+  },
   "devDependencies": {
     "babel-cli": "~6.26.0",
     "babel-core": "~6.26.0",
@@ -47,19 +50,22 @@
     "babel-plugin-transform-es2015-classes": "~6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "~6.26.0",
     "babel-plugin-transform-flow-strip-types": "~6.22.0",
+    "babel-preset-react-native": "^4.0.0",
     "babelify": "~7.3.0",
     "browserify": "~14.4.0",
+    "flow-bin": "~0.53.1",
     "google-closure-compiler": "20170626.0.0",
     "jest-cli": "~20.0.4",
-    "watchify": "~3.7.0",
-    "flow-bin": "~0.53.1"
+    "react": "^16.2.0",
+    "react-native": "^0.51.0",
+    "watchify": "~3.7.0"
   },
   "scripts": {
     "test": "jest",
     "build": "babel src --ignore __tests__,__mocks,FlowTypes.js --out-dir build2",
     "watch": "babel --ignore __tests__,__mocks,FlowTypes.js --watch src --out-dir build2",
-    "dist-dev": "mkdir -p dist && browserify src/jsmediatags.js --detect-globals false -i ./src/NodeFileReader.js -o dist/jsmediatags.js -s jsmediatags -t babelify",
-    "dist-watch": "mkdir -p dist && watchify src/jsmediatags.js -v --detect-globals false -i ./src/NodeFileReader.js -o dist/jsmediatags.js -s jsmediatags -t babelify",
+    "dist-dev": "mkdir -p dist && browserify src/jsmediatags.js --detect-globals false -i ./src/NodeFileReader.js -i ./src/ReactNativeFileReader.js -o dist/jsmediatags.js -s jsmediatags -t babelify",
+    "dist-watch": "mkdir -p dist && watchify src/jsmediatags.js -v --detect-globals false -i ./src/NodeFileReader.js -i ./src/ReactNativeFileReader.js -o dist/jsmediatags.js -s jsmediatags -t babelify",
     "dist": "npm run dist-dev && java -jar node_modules/google-closure-compiler/compiler.jar --warning_level QUIET --compilation_level SIMPLE_OPTIMIZATIONS --js dist/jsmediatags.js > dist/jsmediatags.min.js"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "url": "https://github.com/aadsm/jsmediatags/issues"
   },
   "homepage": "https://github.com/aadsm/jsmediatags#readme",
+  "react-native": {
+    "fs": false
+  },
   "dependencies": {
     "xhr2": "^0.1.4"
   },

--- a/src/ReactNativeFileReader.js
+++ b/src/ReactNativeFileReader.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const RNFS = require('react-native-fs');
+const { Buffer } = require('buffer');
 
 const ChunkedFileData = require('./ChunkedFileData');
 const MediaFileReader = require('./MediaFileReader');
@@ -56,8 +57,10 @@ class ReactNativeFileReader extends MediaFileReader {
     var onSuccess = callbacks.onSuccess;
     var onError = callbacks.onError || function(object){};
 
-    RNFS.read(this._path, length, range[0])
-      .then(data => {
+    RNFS.read(this._path, length, range[0], {encoding: 'base64'})
+      .then(readData => {
+        const buffer = new Buffer(readData, 'base64');
+        const data = Array.prototype.slice.call(buffer, 0, length);
         fileData.addData(range[0], data);
         onSuccess();
       })

--- a/src/ReactNativeFileReader.js
+++ b/src/ReactNativeFileReader.js
@@ -39,10 +39,11 @@ class ReactNativeFileReader extends MediaFileReader {
 
     RNFS.stat(self._path)
       .then(statResult => {
-        self._size = statResult.size
+        self._size = statResult.size;
+        callbacks.onSuccess();
       })
       .catch(error => {
-        callbacks.onError({"type": "fs", "info": error})
+        callbacks.onError({"type": "fs", "info": error});
       })
   }
 

--- a/src/ReactNativeFileReader.js
+++ b/src/ReactNativeFileReader.js
@@ -1,0 +1,69 @@
+/**
+ * @flow
+ */
+'use strict';
+
+const RNFS = require('react-native-fs');
+
+const ChunkedFileData = require('./ChunkedFileData');
+const MediaFileReader = require('./MediaFileReader');
+
+import type {
+  LoadCallbackType
+} from './FlowTypes';
+
+
+class ReactNativeFileReader extends MediaFileReader {
+  _path: string;
+  _fileData: ChunkedFileData;
+
+  constructor(path: string) {
+    super();
+    this._path = path;
+    this._fileData = new ChunkedFileData();
+  }
+
+  static canReadFile(file: any): boolean {
+    return (
+      typeof file === 'string' &&
+      !/^[a-z]+:\/\//i.test(file)
+    );
+  }
+
+  getByteAt(offset: number): number {
+    return this._fileData.getByteAt(offset);
+  }
+
+  _init(callbacks: LoadCallbackType) {
+    var self = this;
+
+    RNFS.stat(self._path)
+      .then(statResult => {
+        self._size = statResult.size
+      })
+      .catch(error => {
+        callbacks.onError({"type": "fs", "info": error})
+      })
+  }
+
+  loadRange(range: [number, number], callbacks: LoadCallbackType) {
+    var fd = -1;
+    var self = this;
+    var fileData = this._fileData;
+
+    var length = range[1] - range[0] + 1;
+    var onSuccess = callbacks.onSuccess;
+    var onError = callbacks.onError || function(object){};
+
+    RNFS.read(this._path, length, range[0])
+      .then(data => {
+        fileData.addData(range[0], data);
+        onSuccess();
+      })
+      .catch(err => {
+        onError({"type": "fs", "info": err});
+      });
+  }
+}
+
+module.exports = ReactNativeFileReader;

--- a/src/jsmediatags.js
+++ b/src/jsmediatags.js
@@ -3,9 +3,9 @@
  */
 'use strict';
 
-const ReactNativeFileReader = require("./ReactNativeFileReader");
+const NodeFileReader = require('./NodeFileReader');
+const ReactNativeFileReader = require('./ReactNativeFileReader');
 const MediaFileReader = require("./MediaFileReader");
-const NodeFileReader = require("./NodeFileReader");
 const XhrFileReader = require("./XhrFileReader");
 const BlobFileReader = require("./BlobFileReader");
 const ArrayFileReader = require("./ArrayFileReader");
@@ -273,10 +273,12 @@ Config
   .addTagReader(MP4TagReader)
   .addTagReader(FLACTagReader);
 
-
 if (typeof process !== "undefined" && !process.browser) {
-  Config.addFileReader(ReactNativeFileReader);
-  Config.addFileReader(NodeFileReader);
+  if (typeof navigator !== "undefined" && navigator.product === "ReactNative") {
+    Config.addFileReader(ReactNativeFileReader);
+  } else {
+    Config.addFileReader(NodeFileReader);
+  }
 }
 
 module.exports = {

--- a/src/jsmediatags.js
+++ b/src/jsmediatags.js
@@ -3,6 +3,7 @@
  */
 'use strict';
 
+const ReactNativeFileReader = require("./ReactNativeFileReader");
 const MediaFileReader = require("./MediaFileReader");
 const NodeFileReader = require("./NodeFileReader");
 const XhrFileReader = require("./XhrFileReader");
@@ -272,7 +273,11 @@ Config
   .addTagReader(MP4TagReader)
   .addTagReader(FLACTagReader);
 
+
 if (typeof process !== "undefined" && !process.browser) {
+  if (ReactNativeFileReader) {
+    Config.addFileReader(ReactNativeFileReader);
+  }
   Config.addFileReader(NodeFileReader);
 }
 

--- a/src/jsmediatags.js
+++ b/src/jsmediatags.js
@@ -275,9 +275,7 @@ Config
 
 
 if (typeof process !== "undefined" && !process.browser) {
-  if (ReactNativeFileReader) {
-    Config.addFileReader(ReactNativeFileReader);
-  }
+  Config.addFileReader(ReactNativeFileReader);
   Config.addFileReader(NodeFileReader);
 }
 


### PR DESCRIPTION
@aadsm this PR adds a "working" example with `react-native`. 

I've been able to use the tag reader in my `react-native` app with the following manual steps:

1. Install the package with `build2/` as built.
2. Within `build2/`, remove `NodeFileReader.js` and all references to `NodeFileReader` in `jsmediatags.js`.

This PR should be ready to merge once the following is handled or at least considered:

1. Check the [buffer](https://github.com/feross/buffer) dependency and consider if this is worth adding.
2. Figure out conditional dependency resolution between node/react-native. I'm currently using `optionalPeerDependencies` and not sure if there is a better approach.
3. Consider a way to share common code and distribute separate packages within this repo based on environment (e.g. `jsmediatags`, `jsmediatags-node`, `jsmediatags-rn`)--this approach probably handles 1 and 2; could consider webpack too.
4. Figure out a good testing strategy and write a few tests.

See issue #82 