### PR TITLE
Included the audio file's path with returned tags

### DIFF
--- a/dist/jsmediatags.js
+++ b/dist/jsmediatags.js
@@ -145,7 +145,7 @@ module.exports = BlobFileReader;
  * This class does not load the data, it just manages it. It provides operations
  * to add and read data from the file.
  *
- * 
+ *
  */
 'use strict';
 
@@ -1567,7 +1567,7 @@ module.exports = ID3v2TagReader;
  *   http://atomicparsley.sourceforge.net/mpeg-4files.html
  *   http://developer.apple.com/mac/library/documentation/QuickTime/QTFF/Metadata/Metadata.html
  * Authored by Joshua Kifer <joshua.kifer gmail.com>
- * 
+ *
  */
 'use strict';
 
@@ -2202,7 +2202,11 @@ var MediaTagReader = function () {
               }
 
               // TODO: destroy mediaFileReader
-              callbacks.onSuccess(tags);
+
+              // We also return the file path so we can
+              // ... include it the tracks meta.
+              // ... i.e meta.source
+              callbacks.onSuccess(tags, self._mediaFileReader._path);
             },
             onError: callbacks.onError
           });

--- a/src/MediaTagReader.js
+++ b/src/MediaTagReader.js
@@ -64,7 +64,11 @@ class MediaTagReader {
             }
 
             // TODO: destroy mediaFileReader
-            callbacks.onSuccess(tags);
+
+            // We also return the file path so we can
+            // ... include it the tracks meta.
+            // ... i.e meta.source
+            callbacks.onSuccess(tags, self._mediaFileReader._path);
           },
           onError: callbacks.onError
         });


### PR DESCRIPTION
We might want our (`onSuccess`) callback function to also return the `path` of the audio file it read along with its `tags`. So that we can properly construct the following track object for example;

```js
conts jsm = require('jsmediatags')

new jsm.Reader('/path/to/file').setTagsToRead(['
    title', 'artist', 'album', 'genre', 'picture', 'year'
]).read({
    onSuccess: (tag, path) => {
        var raw_title = path.slice(path.lastIndexOf('/')+1, path.length)
        raw_title = raw_title.split('.')[0]

        console.log({
            title: !tag.tags.title ? raw_title : tag.tags.title,
            artist: !tag.tags.artist ? 'Unknown' : tag.tags.artist,
            // ... 
        })
    },
    onError: (error) => {
        console.debug(error)   
    }
})
```