### PR TITLE
Add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     }
   ],
   "main": "build2/jsmediatags.js",
+  "browser": "dist/jsmediatags.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aadsm/jsmediatags.git"


### PR DESCRIPTION
Hi. I'd like to use `jsmediatags` in-browser, but as an npm package bundled by Webpack.

Currently it doesn't work because `build2/jsmediatags.js` tries to require `fs` (for `NodeFileReader`), which obviously doesn't work in a browser.

Specifying `dist/jsmediatags.js` as the [browser field](https://docs.npmjs.com/files/package.json#browser) in package.json allows it to work. 🙂