### PR TITLE
Docs: add description to avoid 'no suitable file reader found' pitfall

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ jsmediatags.read("http://www.example.com/music-file.mp3", {
   }
 });
 ```
+
+Note that URL has to include scheme(absolute URL).Relative URL is not supported for now.
+
+
 ```javascript
 // From Blob
 jsmediatags.read(blob, ...);

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ jsmediatags.read("http://www.example.com/music-file.mp3", {
 });
 ```
 
-Note that URL has to include scheme(absolute URL).Relative URL is not supported for now.
+Note that the URI has to include the scheme (e.g.: https://), as relative URIs are not supported.
 
 
 ```javascript


### PR DESCRIPTION
I encountered the same error as #51 with 'no suitable file reader found for...' because of passing relative URL to the reader. Since the relative path is unlikely to be supported It'd be better if this pitfall is documented.