### PR TITLE
Do not unsynchronize frames twice.

### DIFF
--- a/src/ID3v2FrameReader.js
+++ b/src/ID3v2FrameReader.js
@@ -249,7 +249,7 @@ class ID3v2FrameReader {
       }
 
       var unsyncData;
-      if (flags && flags.format.unsynchronisation) {
+      if (flags && flags.format.unsynchronisation && !id3header.flags.unsynchronisation) {
         frameData = this.getUnsyncFileReader(frameData, frameDataOffset, frameSize);
         frameDataOffset = 0;
         frameSize = frameData.getSize();

--- a/src/__tests__/ID3v2TagReader-test.js
+++ b/src/__tests__/ID3v2TagReader-test.js
@@ -284,6 +284,41 @@ describe("ID3v2TagReader", function() {
         expect(tags.tags.picture.data).toEqual([0x01, 0x02, 0xff, 0x03, 0x04, 0x05]);
       });
     });
+
+    it("doesn't unsynchronise frames twice", function() {
+      var id3FileContents =
+        new ID3v2TagContents(4, 3)
+          .setFlags({
+            unsynchronisation: true
+          })
+          .addFrame("TIT2", [].concat(
+            [0x00], // encoding
+            bin("The title"), [0x00]
+          ))
+          .addFrame("APIC", [].concat(
+            [0x00], // text encoding
+            bin("image/jpeg"), [0x00],
+            [0x03], // picture type - cover front
+            bin("front cover image"), [0x00],
+            [0x01, 0x02, 0xff, 0x00, 0x00, 0x03, 0x04, 0x05] // image data
+          ), {
+            format: {
+              unsynchronisation: true
+            }
+          });
+      mediaFileReader = new ArrayFileReader(id3FileContents.toArray());
+      tagReader = new ID3v2TagReader(mediaFileReader);
+
+      return new Promise(function(resolve, reject) {
+        tagReader.read({
+          onSuccess: resolve,
+          onFailure: reject
+        });
+        jest.runAllTimers();
+      }).then(function(tags) {
+        expect(tags.tags.picture.data).toEqual([0x01, 0x02, 0xff, 0x00, 0x03, 0x04, 0x05]);
+      });
+    });
   });
 
   it("should process frames with no content", function() {


### PR DESCRIPTION
If the tag has the unsynchronization flag set and one of the frames'
format flag also specifies unsynchronization, then the frame should
be unsynchronized just once.