### PR TITLE
Fix picture conversion function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,10 +273,10 @@ The `picture` tag contains an array buffer of all the bytes of the album artwork
 ```javascript
 const { data, format } = result.tags.picture;
 let base64String = "";
-for (const i = 0; i < data.length; i++) {
+for (let i = 0; i < data.length; i++) {
   base64String += String.fromCharCode(data[i]);
 }
-img.src = `data:${data.format};base64,${window.btoa(base64String)}`;
+img.src = `data:${format};base64,${window.btoa(base64String)}`;
 ```
 
 ### HTTP Access Control (CORS)


### PR DESCRIPTION
There were two issues I noticed when I copied over the example conversion function from ArrayBuffer to Base64 data url.  

First, the `i` index variable is declared as a `const` when it should be a `let`.

Second, the `data` variable is being destructured from the `picture` tag but never used.

Both of these typos are fixed in this PR