### PR TITLE
Fix 'browser' field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   ],
   "main": "build2/jsmediatags.js",
-  "browser": "dist/jsmediatags.js",
+  "browser": "dist/jsmediatags.min.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aadsm/jsmediatags.git"


### PR DESCRIPTION
`dist/jsmediatags.js` is not published since https://github.com/aadsm/jsmediatags/commit/2cc8ca5f49d788e360a3a9f18dc425e99ebf2af3

That causes error when using vite:
```
4:14:56 PM [vite] Internal server error: Failed to resolve entry for package "jsmediatags". The package may have incorrect main/module/exports specified in its package.json.
```