### PR TITLE
Fix file link in 'browser' property

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   ],
   "main": "build2/jsmediatags.js",
-  "browser": "dist/jsmediatags.js",
+  "browser": "dist/jsmediatags.min.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aadsm/jsmediatags.git"


### PR DESCRIPTION
In file link, you are missing .min.js extension, so this isn't working correctly in some projects.