### PR TITLE
Update package.json [Bug fixing]

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   ],
   "main": "build2/jsmediatags.js",
-  "browser": "dist/jsmediatags.js",
+  "browser": "dist/jsmediatags.min.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aadsm/jsmediatags.git"


### PR DESCRIPTION
[error message]: The package may have incorrect main/module/exports specified in its package.json

[solution]: "browser": "dist/jsmediatags.min.js",

[Description]: In the package.json, the browser is supposed to have a "browser": "dist/jsmediatags.min.js", and not "browser": "dist/jsmediatags.js" to work well in the browser.