### PR TITLE
Adds support for ID3 synchronized lyrics (SYLT)

### DIFF
--- a/src/ID3v2FrameReader.js
+++ b/src/ID3v2FrameReader.js
@@ -539,20 +539,24 @@ frameReaderFunctions['SYLT'] = function readSynchronizedLyricsFrame(
   flags: ?Object,
   id3header?: TagHeader
 ): any {
+  var start = offset;
   var contentTypes = ['other', 'lyrics', 'transcription', 'movement', 'events', 'chord', 'trivia'];
-  var timeStampFormats = ['frames', 'milliseconds'];
+  var timeStampFormats = ['unset', 'frames', 'milliseconds'];
   var charset = getTextEncoding(data.getByteAt(offset));
-  var language = data.getStringAt(offset+1, 3);
-  var timeStampFormat = timeStampFormats[data.getByteAt(offset+4)];
-  var contentType = contentTypes[data.getByteAt(offset+5)];
-  var descriptor = StringUtils.readNullTerminatedString(data.getBytesAt(offset+6, length-offset-6));
-  offset += 6 + descriptor.bytesReadCount;
-
+  offset += 1;
+  var language = data.getStringAt(offset, 3);
+  offset += 3;
+  var timeStampFormat = timeStampFormats[data.getByteAt(offset)];
+  offset += 1;
+  var contentType = contentTypes[data.getByteAt(offset)];
+  offset += 1;
+  var descriptor = data.getStringWithCharsetAt(offset, length + start - offset, charset);
+  offset += descriptor.bytesReadCount;
   var synchronisedText = [];
   var line = '';
 
-  while (offset < length) {
-    line = StringUtils.readNullTerminatedString(data.getBytesAt(offset, length-offset));
+  while (offset < length + start) {
+    line = data.getStringWithCharsetAt(offset, length + start - offset, charset);
     offset += line.bytesReadCount;
     synchronisedText.push({
       text : line.toString(),

--- a/src/__tests__/ID3v2FrameReader-test.js
+++ b/src/__tests__/ID3v2FrameReader-test.js
@@ -94,7 +94,7 @@ describe("ID3v2FrameReader", function() {
     var fileData = [].concat(
       [0x00], // encoding
       bin("ENG"), // language
-      [0x01], // time stamp format
+      [0x02], // time stamp format
       [0x02], // content type
       [0x00], // content descriptor
       bin("Hi"), [0x00],

--- a/src/__tests__/ID3v2FrameReader-test.js
+++ b/src/__tests__/ID3v2FrameReader-test.js
@@ -86,6 +86,40 @@ describe("ID3v2FrameReader", function() {
     expect(data).toEqual(6575);
   });
 
+  it("should read SYLT tag", function() {
+    var frameReader = ID3v2FrameReader.getFrameReaderFunction("SYLT");
+
+    expect(frameReader).toBeDefined();
+
+    var fileData = [].concat(
+      [0x00], // encoding
+      bin("ENG"), // language
+      [0x01], // time stamp format
+      [0x02], // content type
+      [0x00], // content descriptor
+      bin("Hi"), [0x00],
+      [0x00, 0x00, 0x00, 0x00],
+      bin(" there!"), [0x00],
+      [0x00, 0x00, 0x00, 0x64]
+    );
+    var fileReader = new ArrayFileReader(fileData);
+    var data = frameReader(0, fileData.length, fileReader);
+
+    expect(data).toEqual({
+      language: "ENG",
+      timeStampFormat: "milliseconds",
+      contentType: "transcription",
+      descriptor: "",
+      synchronisedText: [{
+        text: "Hi",
+        timeStamp: 0
+      }, {
+        text: " there!",
+        timeStamp: 100
+      }]
+    });
+  });
+
   describe("T* text tags", function() {
     describe("T000 - TZZZ, excluding TXXX", function() {
       var frameReader = ID3v2FrameReader.getFrameReaderFunction("T*");


### PR DESCRIPTION
This PR adds a handler for SYLT data, creating a data structure like this for each SYLT tag:

```javascript
{
    language: "ENG",
    timeStampFormat: "milliseconds",
    contentType: "transcription",
    descriptor: "",
    synchronisedText: [{
        text: "Hi",
        timeStamp: 0
    }, {
        text: " there!",
        timeStamp: 100
    }]
}
```

This is based on the spec here [https://id3.org/id3v2.3.0#Synchronised_lyrics.2Ftext](https://id3.org/id3v2.3.0#Synchronised_lyrics.2Ftext) and (in addition to the included `ID3v2FrameReader-test.js` SYLT test) has been tested on MP3's with SYLT data composed by `node-id3`.

I created string mappings for `timeStampFormat` and `contentType` because I wasn't sure whether this library prefers something that's readable or the actual integers, but I'm happy to remove the strings and use integers instead for these if preferred.