### PR TITLE
Fixes incorrect time stamps on SYLT.

### DIFF
--- a/src/ID3v2FrameReader.js
+++ b/src/ID3v2FrameReader.js
@@ -560,7 +560,7 @@ frameReaderFunctions['SYLT'] = function readSynchronizedLyricsFrame(
     offset += line.bytesReadCount;
     synchronisedText.push({
       text : line.toString(),
-      timeStamp : data.getSynchsafeInteger32At(offset)
+      timeStamp : data.getLongAt(offset, true)
     });
     offset += 4;
   }


### PR DESCRIPTION
Looks like I used the wrong method to convert time stamp numbers in the original PR for SYLT. This fixes that bug.